### PR TITLE
more monument tweaks

### DIFF
--- a/common/great_projects/aelantir.txt
+++ b/common/great_projects/aelantir.txt
@@ -58,7 +58,7 @@ atlantis = {
 		}
 		country_modifiers = {
 			administrative_efficiency = 0.025
-			naval_forcelimit_modifier = 0.1
+			naval_forcelimit_modifier = 0.05
 		}
 		on_upgraded = {
 		}
@@ -86,7 +86,7 @@ atlantis = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 6000
 		}
 		province_modifiers = {
 		}
@@ -188,7 +188,7 @@ malacnar_city_of_warriors = {
 			province_trade_power_value = 5
 		}
 		area_modifier = {
-			local_manpower_modifier = 0.2
+			local_manpower_modifier = 0.15
 		}
 		country_modifiers = {
 			army_tradition_from_battle = 0.5
@@ -220,7 +220,7 @@ malacnar_city_of_warriors = {
 			province_trade_power_value = 10
 		}
 		area_modifier = {
-			local_manpower_modifier = 0.33
+			local_manpower_modifier = 0.2
 		}
 		country_modifiers = {
 			army_tradition_from_battle = 1
@@ -304,6 +304,7 @@ vels_bacar_scol_mecynn = {
 			local_development_cost = -0.05
 		}
 		area_modifier = {
+			local_manpower_modifier = 0.05
 		}
 		country_modifiers = {
 			shock_damage = 0.025
@@ -322,6 +323,7 @@ vels_bacar_scol_mecynn = {
 			local_development_cost = -0.1
 		}
 		area_modifier = {
+			local_manpower_modifier = 0.1
 		}
 		country_modifiers = {
 			shock_damage = 0.05
@@ -342,6 +344,7 @@ vels_bacar_scol_mecynn = {
 			allowed_num_of_buildings = 1
 		}
 		area_modifier = {
+			local_manpower_modifier = 0.15
 		}
 		country_modifiers = {
 			shock_damage = 0.10
@@ -425,7 +428,7 @@ grebniesth_hedge_gardens = {
 			local_unrest = -1
 		}
 		country_modifiers = {
-			prestige = 0.1
+			prestige = 0.25
 			reinforce_speed = 0.05
 		}
 		on_upgraded = {
@@ -445,7 +448,7 @@ grebniesth_hedge_gardens = {
 			local_unrest = -3
 		}
 		country_modifiers = {
-			prestige = 0.25
+			prestige = 0.5
 			reinforce_speed = 0.1
 		}
 		on_upgraded = {
@@ -552,7 +555,7 @@ stanyrhrada_golden_dome = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 2000
 		}
 		province_modifiers = {
 			local_defensiveness = 0.2
@@ -644,14 +647,14 @@ ixazulcucua_leechfathers_maw = {
 			factor = 1000
 		}
 		province_modifiers = {
-			local_development_cost = -0.05
+			local_development_cost = -0.075
 			local_tax_modifier = 0.1
 		}
 		area_modifier = {
 			local_unrest = -1
 		}
 		country_modifiers = {
-			tolerance_own = 0.5
+			tolerance_own = 1
 		}
 		on_upgraded = {
 		}
@@ -664,14 +667,14 @@ ixazulcucua_leechfathers_maw = {
 			factor = 2500
 		}
 		province_modifiers = {
-			local_development_cost = -0.1
+			local_development_cost = -0.15
 			local_tax_modifier = 0.2
 		}
 		area_modifier = {
 			local_unrest = -2
 		}
 		country_modifiers = {
-			tolerance_own = 1
+			tolerance_own = 1.5
 			global_missionary_strength = 0.01
 			missionaries = 1
 		}
@@ -690,14 +693,14 @@ ixazulcucua_leechfathers_maw = {
 			factor = 5000
 		}
 		province_modifiers = {
-			local_development_cost = -0.15
+			local_development_cost = -0.25
 			local_tax_modifier = 0.3
 		}
 		area_modifier = {
 			local_unrest = -3
 		}
 		country_modifiers = {
-			tolerance_own = 1.5
+			tolerance_own = 2
 			global_missionary_strength = 0.02
 			harsh_treatment_cost = -0.2
 		}
@@ -788,7 +791,7 @@ orenkoraim_nakar_koraim = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 3000
 		}
 		province_modifiers = {
 			local_development_cost = -0.15
@@ -908,7 +911,7 @@ gift_of_spring = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 2500
 		}
 		province_modifiers = {
 		}
@@ -927,7 +930,7 @@ gift_of_spring = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 5000
 		}
 		province_modifiers = {
 		}
@@ -946,7 +949,7 @@ gift_of_spring = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 10000
 		}
 		province_modifiers = {
 		}
@@ -1046,7 +1049,7 @@ gift_of_summer = {
 		}
 		country_modifiers = {
 			global_trade_power = 0.1
-			trade_steering = 0.1
+			trade_steering = 0.05
 		}
 		on_upgraded = {
 		}
@@ -1064,7 +1067,7 @@ gift_of_summer = {
 		}
 		country_modifiers = {
 			global_trade_power = 0.1
-			trade_steering = 0.2
+			trade_steering = 0.1
 		}
 		on_upgraded = {
 		}
@@ -1082,7 +1085,7 @@ gift_of_summer = {
 		}
 		country_modifiers = {
 			global_trade_power = 0.15
-			trade_steering = 0.33
+			trade_steering = 0.2
 		}
 		on_upgraded = {
 		}

--- a/common/great_projects/anb_monuments_cannor.txt
+++ b/common/great_projects/anb_monuments_cannor.txt
@@ -82,7 +82,7 @@ bal_vertesk = {
 
 		country_modifiers = {
 			prestige = 0.1
-			spy_offence = 0.05
+			spy_offence = 0.10
 		}
 
 		on_upgraded = {
@@ -118,7 +118,7 @@ bal_vertesk = {
 
 		country_modifiers = {
 			prestige = 0.25
-			spy_offence = 0.05
+			spy_offence = 0.10
 			global_spy_defence = 0.10
 		}
 
@@ -157,7 +157,7 @@ bal_vertesk = {
 		country_modifiers = {
 			prestige = 0.5
 			global_unrest = -1 #maybe nerf this to local?
-			spy_offence = 0.15
+			spy_offence = 0.2
 			global_spy_defence = 0.20
 		}
 
@@ -424,7 +424,7 @@ bal_dostan = {
 
 		province_modifiers = {
 			local_defensiveness = 0.05
-				hostile_attrition = 1
+			hostile_attrition = 1
 		}
 
 		area_modifier = {
@@ -473,7 +473,7 @@ bal_dostan = {
 
 		province_modifiers = {
 			local_defensiveness = 0.1
-				hostile_attrition = 2
+			hostile_attrition = 2
 		}
 
 		area_modifier = {
@@ -525,7 +525,7 @@ bal_dostan = {
 
 		province_modifiers = {
 			local_defensiveness = 0.10
-				hostile_attrition = 3
+			hostile_attrition = 3
 		}
 
 		area_modifier = {
@@ -627,7 +627,7 @@ bal_vroren = {
 
 		province_modifiers = {
 			local_defensiveness = 0.05
-			# garrison_size = 0.05 # Paradox pls fix
+			local_garrison_size = 0.05 
 		}
 
 		area_modifier = {
@@ -664,7 +664,7 @@ bal_vroren = {
 
 		province_modifiers = {
 			local_defensiveness = 0.1
-			# garrison_size = 0.10 # Paradox pls fix
+			local_garrison_size = 0.10
 		}
 
 		area_modifier = {
@@ -702,7 +702,7 @@ bal_vroren = {
 
 		province_modifiers = {
 			local_defensiveness = 0.10
-			# garrison_size = 0.15 # Paradox pls fix
+			local_garrison_size = 0.15 
 		}
 
 		area_modifier = {
@@ -835,7 +835,7 @@ bal_hyl = {
 		}
 
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 1500
 		}
 
 		province_modifiers = {
@@ -873,7 +873,7 @@ bal_hyl = {
 		}
 
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 6000
 		}
 
 		province_modifiers = {
@@ -1056,7 +1056,7 @@ bal_mire = {
 		}
 
 		province_modifiers = {
-			local_defensiveness = 0.10
+			local_defensiveness = 0.20
 			local_manpower_modifier = 0.50
 		}
 
@@ -1328,7 +1328,7 @@ aelcandar = {
 		country_modifiers = {
 		    prestige = 0.1
 			harsh_treatment_cost = -0.1
-			merc_maintenance_modifier = -0.05
+			merc_maintenance_modifier = -0.1
 		}
 
 		on_upgraded = {
@@ -1354,7 +1354,7 @@ aelcandar = {
 		country_modifiers = {
 		    prestige = 0.25
 			harsh_treatment_cost = -0.2
-			merc_maintenance_modifier = -0.1
+			merc_maintenance_modifier = -0.15
 		}
 
 		on_upgraded = {
@@ -1382,7 +1382,7 @@ aelcandar = {
 		country_modifiers = {
 		    prestige = 0.5
 			harsh_treatment_cost = -0.3
-			merc_maintenance_modifier = -0.15
+			merc_maintenance_modifier = -0.25
 		}
 
 		on_upgraded = {
@@ -1469,6 +1469,7 @@ escandar = {
 		    prestige = 0.1
 			imperial_mercenary_cost = -0.05
 			general_cost = -0.05
+			improve_relation_modifier = 0.05
 		}
 
 		on_upgraded = {
@@ -1492,9 +1493,10 @@ escandar = {
 		}
 
 		country_modifiers = {
-		    prestige = 0.25
+		    	prestige = 0.25
 			imperial_mercenary_cost = -0.1
 			general_cost = -0.10
+			improve_relation_modifier = 0.1
 		}
 
 		on_upgraded = {
@@ -1524,6 +1526,7 @@ escandar = {
 			imperial_mercenary_cost = -0.15
 			general_cost = -0.15
 			may_recruit_female_generals = yes
+			improve_relation_modifier = 0.15
 		}
 
 		on_upgraded = {
@@ -1608,7 +1611,7 @@ calascandar = {
 		}
 
 		country_modifiers = {
-		    prestige = 0.1
+		    	prestige = 0.1
 			heir_chance = 0.25
 			dip_advisor_cost = -0.05
 			power_projection_from_insults = 0.05
@@ -1664,7 +1667,7 @@ calascandar = {
 		}
 
 		country_modifiers = {
-		    prestige = 0.5
+		    	prestige = 0.5
 			heir_chance = 1
 			dip_advisor_cost = -0.15
 			power_projection_from_insults = 0.15
@@ -1755,7 +1758,7 @@ the_necropolis = {
 
 		area_modifier = {
 			local_autonomy = -0.025
-			local_tax_modifier = 0.05
+			local_tax_modifier = 0.1
 		}
 
 		country_modifiers = {
@@ -1790,7 +1793,7 @@ the_necropolis = {
 
 		
 		area_modifier = {
-			local_tax_modifier = 0.10
+			local_tax_modifier = 0.20
 		}
 
 		
@@ -1830,7 +1833,7 @@ the_necropolis = {
 
 		
 		area_modifier = {
-			local_tax_modifier = 0.15
+			local_tax_modifier = 0.30
 		}
 
 		


### PR DESCRIPTION
cannor:
bal vertesk - gave them slightly more spy network construction, may need more buffs tbh
bal ouord - looks fine
bal dostan - looks like a great fort, might want to buff earliy tiers if it isn't on a defendable terrain
bal vroren - buffed it by fixing a bug regarding garison size, may still want to buff further
bal hyl - moved 1k of tier 2's cost to tier 3
bal mire - double tier 3 defensivness for the province
the north citadel - seems really solid
aelcandar - increased the merc maintenance cost reduction
escandar - added 5%-10%-15% improve relations modifier
calascandar - looked fine
the necropolis - buffed the area tax modifier