### PR TITLE
Monument tweaks

### DIFF
--- a/common/great_projects/bulwar.txt
+++ b/common/great_projects/bulwar.txt
@@ -99,7 +99,7 @@ temple_of_surael = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 4000
 		}
 		province_modifiers = {
 		}
@@ -178,14 +178,15 @@ hanging_gardens = {
 			factor = 1000
 		}
 		province_modifiers = {
-			local_development_cost = -0.1
+			local_development_cost = -0.05
 		}
 		area_modifier = {
 			trade_goods_size_modifier = 0.1
+			local_development_cost = -0.05
 		}
 		country_modifiers = {
 			num_accepted_cultures = 1
-			stability_cost_modifier = -0.05
+			stability_cost_modifier = -0.1
 		}
 		on_upgraded = {
 		}
@@ -198,15 +199,16 @@ hanging_gardens = {
 			factor = 2500
 		}
 		province_modifiers = {
-			local_development_cost = -0.15
+			local_development_cost = -0.075
 		}
 		area_modifier = {
 			trade_goods_size_modifier = 0.15
 			local_prosperity_growth = 0.5
+			local_development_cost = -0.075
 		}
 		country_modifiers = {
 			num_accepted_cultures = 2
-			stability_cost_modifier = -0.1
+			stability_cost_modifier = -0.2
 		}
 		on_upgraded = {
 		}
@@ -219,15 +221,16 @@ hanging_gardens = {
 			factor = 5000
 		}
 		province_modifiers = {
-			local_development_cost = -0.2
+			local_development_cost = -0.1
 		}
 		area_modifier = {
 			trade_goods_size_modifier = 0.25
 			local_prosperity_growth = 1
+			local_development_cost = -0.1
 		}
 		country_modifiers = {
 			num_accepted_cultures = 3
-			stability_cost_modifier = -0.15
+			stability_cost_modifier = -0.25
 		}
 		on_upgraded = {
 		}
@@ -303,7 +306,7 @@ fortress_azka_szel = {
 		}
 		country_modifiers = {
 			missionary_maintenance_cost = -0.1
-			manpower_in_true_faith_provinces = 0.05
+			manpower_in_true_faith_provinces = 0.075
 		}
 		on_upgraded = {
 		}
@@ -322,7 +325,7 @@ fortress_azka_szel = {
 		}
 		country_modifiers = {
 			missionary_maintenance_cost = -0.3
-			manpower_in_true_faith_provinces = 0.1
+			manpower_in_true_faith_provinces = 0.15
 			establish_order_cost = -0.1
 		}
 		on_upgraded = {
@@ -342,7 +345,7 @@ fortress_azka_szel = {
 		}
 		country_modifiers = {
 			missionary_maintenance_cost = -0.5
-			manpower_in_true_faith_provinces = 0.15
+			manpower_in_true_faith_provinces = 0.25
 			establish_order_cost = -0.2
 		}
 		on_upgraded = {
@@ -410,7 +413,7 @@ fortress_azka_sur = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 750
 		}
 		province_modifiers = {
 			local_defensiveness = 0.1
@@ -430,7 +433,7 @@ fortress_azka_sur = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 1500
 		}
 		province_modifiers = {
 			local_defensiveness = 0.2
@@ -450,7 +453,7 @@ fortress_azka_sur = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 3000
 		}
 		province_modifiers = {
 			local_defensiveness = 0.33
@@ -659,6 +662,7 @@ temple_sun = {
 		country_modifiers = {
 			global_heretic_missionary_strength = 0.01
 			church_loyalty_modifier = 0.05
+			land_morale = 0.025
 		}
 		on_upgraded = {
 			owner = {
@@ -684,6 +688,7 @@ temple_sun = {
 			global_heretic_missionary_strength = 0.03
 			church_loyalty_modifier = 0.075
 			church_influence_modifier = 0.025
+			land_morale = 0.05
 		}
 		on_upgraded = {
 			owner = {
@@ -710,6 +715,7 @@ temple_sun = {
 			church_loyalty_modifier = 0.1
 			church_influence_modifier = 0.05
 			missionaries = 1
+			land_morale = 0.075
 		}
 		on_upgraded = {
 			owner = {
@@ -1438,7 +1444,7 @@ eranils_oddities = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 2500
 		}
 		province_modifiers = {
 			trade_goods_size_modifier = 0.1
@@ -1457,7 +1463,7 @@ eranils_oddities = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 5000
 		}
 		province_modifiers = {
 			trade_goods_size_modifier = 0.15
@@ -1476,7 +1482,7 @@ eranils_oddities = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 10000
 		}
 		province_modifiers = {
 			trade_goods_size_modifier = 0.2

--- a/common/great_projects/dalr.txt
+++ b/common/great_projects/dalr.txt
@@ -76,6 +76,7 @@ bjarnrik_staple_port_of_konungrhavn = {
 		}
 		province_modifiers = {
 			local_development_cost = -0.05
+			province_trade_power_value = 5
 		}
 		area_modifier = {
 		}
@@ -95,7 +96,7 @@ bjarnrik_staple_port_of_konungrhavn = {
 		}
 		province_modifiers = {
 			local_development_cost = -0.1
-			province_trade_power_value = 5
+			province_trade_power_value = 10
 		}
 		area_modifier = {
 		}
@@ -116,7 +117,7 @@ bjarnrik_staple_port_of_konungrhavn = {
 		}
 		province_modifiers = {
 			local_development_cost = -0.15
-			province_trade_power_value = 10
+			province_trade_power_value = 15
 		}
 		area_modifier = {
 		}


### PR DESCRIPTION
bulwar:
temple of surael - made tier 3 slightly cheaper
hanging gardens - increased stablity cost reduction, gave half of the dev cost reduction to the area as well (removed it from province so no net increase there)
Fortress of Azka-szel-Azka - increased manpower in true faith
fortress_azka_sur - made cheaper
Grand Bazaar of Brasan - looked fine
Temples of the Sun - added 2.5%-5%-7.5% morale of armies
Sun-Dial of Azka-Sur - looked fine
Mountain of Clear Sight - bit on the weak side, but it is jadd only so screw them
Port of Emperors- looked fine
Mountains of the Moon- looked fine, might want to switch some hostile attrition for smth else
Stone Palace of Ekluzagnu - skipped for now because code looks weird
Eranil's Oddities - doubled the price

eborthil citadel seemed fine
Staple Port of Konungrhavn - increased province trade power