### PR TITLE
east dameshead monument tweaks

### DIFF
--- a/common/great_projects/east_dameshead.txt
+++ b/common/great_projects/east_dameshead.txt
@@ -80,7 +80,7 @@ anbenncost_imperial_palace = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 800
 		}
 		province_modifiers = {
 			local_defensiveness = 0.1
@@ -376,7 +376,7 @@ silvelar_silver_spires = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 1500
 		}
 		province_modifiers = {
 			gold_depletion_chance_modifier = -0.1
@@ -399,7 +399,7 @@ silvelar_silver_spires = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 3750
 		}
 		province_modifiers = {
 			gold_depletion_chance_modifier = -0.3
@@ -431,7 +431,7 @@ silvelar_silver_spires = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 7500
 		}
 		province_modifiers = {
 			gold_depletion_chance_modifier = -0.5
@@ -530,7 +530,7 @@ menibor_hall_of_the_gallant = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 500
 		}
 		province_modifiers = {
 			local_tax_modifier = 0.33
@@ -550,7 +550,7 @@ menibor_hall_of_the_gallant = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 1000
 		}
 		province_modifiers = {
 		}
@@ -571,7 +571,7 @@ menibor_hall_of_the_gallant = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 2500
 		}
 		province_modifiers = {
 		}


### PR DESCRIPTION
imperial palace in abencost - made the first level a little cheaper port munas -could maybe use a buff
Silver Spires of the Silver Moon - made it a bit more expensive menibor_hall_of_the_gallant - made a lot cheaper
The Moonmount Library - max level takes 65 years with 3 lvl 5's to pay off, so should be fine Temple of the Highest Moon (Damish Temple) - the nation modifier seems kinda bad, but the area stuff is really good so I kept it like this