### PR TITLE
Monument tweaks

### DIFF
--- a/common/great_projects/lencenor.txt
+++ b/common/great_projects/lencenor.txt
@@ -243,7 +243,7 @@ lorent_new_adea_naval_school = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 800
 		}
 		province_modifiers = {
 			local_development_cost = -0.05
@@ -387,7 +387,7 @@ deranne_westport_gateway_to_aelantir = {
 		}
 		country_modifiers = {
 			range = 0.1
-			global_colonial_growth = 5
+			global_colonial_growth = 10
 		}
 		on_upgraded = {
 		}
@@ -406,7 +406,7 @@ deranne_westport_gateway_to_aelantir = {
 		}
 		country_modifiers = {
 			range = 0.25
-			global_colonial_growth = 10
+			global_colonial_growth = 20
 			colonist_placement_chance = 0.025
 		}
 		on_upgraded = {
@@ -435,7 +435,7 @@ deranne_westport_gateway_to_aelantir = {
 		}
 		country_modifiers = {
 			range = 0.33
-			global_colonial_growth = 15
+			global_colonial_growth = 25
 			colonist_placement_chance = 0.05
 		}
 		on_upgraded = {
@@ -538,7 +538,7 @@ minara_temple = {
 		}
 		country_modifiers = {
 			tolerance_own = 0.25
-			improve_relation_modifier = 0.025
+			improve_relation_modifier = 0.05
 		}
 		on_upgraded = {
 		}
@@ -559,7 +559,7 @@ minara_temple = {
 		}
 		country_modifiers = {
 			tolerance_own = 0.5
-			improve_relation_modifier = 0.05
+			improve_relation_modifier = 0.1
 			ae_impact = -0.025
 		}
 		on_upgraded = {
@@ -585,7 +585,7 @@ minara_temple = {
 		}
 		country_modifiers = {
 			tolerance_own = 1
-			improve_relation_modifier = 0.1
+			improve_relation_modifier = 0.15
 			ae_impact = -0.05
 		}
 		on_upgraded = {

--- a/common/great_projects/middle_dwarovar.txt
+++ b/common/great_projects/middle_dwarovar.txt
@@ -83,7 +83,7 @@ verkal_gulan_hero_gate = {
 		}
 		country_modifiers = {
 			yearly_corruption = -0.05
-			inflation_reduction = -0.05
+			inflation_reduction = -0.025
 		}
 		on_upgraded = {
 		}
@@ -103,7 +103,7 @@ verkal_gulan_hero_gate = {
 		}
 		country_modifiers = {
 			yearly_corruption = -0.1
-			inflation_reduction = -0.1
+			inflation_reduction = -0.05
 		}
 		on_upgraded = {
 			define_advisor = {
@@ -132,7 +132,7 @@ verkal_gulan_hero_gate = {
 		}
 		country_modifiers = {
 			yearly_corruption = -0.15
-			inflation_reduction = -0.15
+			inflation_reduction = -0.075
 			monthly_gold_inflation_modifier = -0.5
 		}
 		on_upgraded = {
@@ -222,7 +222,7 @@ seghdihr_home_of_the_seg_band = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 800
 		}
 		province_modifiers = {
 			local_defensiveness = 0.1
@@ -240,7 +240,7 @@ seghdihr_home_of_the_seg_band = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 3700
 		}
 		province_modifiers = {
 			local_defensiveness = 0.2
@@ -497,8 +497,8 @@ gor_vazumbrog_the_vaulthold = {
 		area_modifier = {			
 		}
 		country_modifiers = {
-			fire_damage = 0.01
-			shock_damage = 0.01
+			fire_damage = 0.025
+			shock_damage = 0.025
 		}
 		on_upgraded = {
 		}
@@ -508,7 +508,7 @@ gor_vazumbrog_the_vaulthold = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 2500
 		}
 		province_modifiers = {
 			trade_value_modifier = 0.1
@@ -516,8 +516,8 @@ gor_vazumbrog_the_vaulthold = {
 		area_modifier = {			
 		}
 		country_modifiers = {
-			fire_damage = 0.02
-			shock_damage = 0.02
+			fire_damage = 0.05
+			shock_damage = 0.05
 			artificers_loyalty_modifier = 0.05
 			artificers_influence_modifier = 0.025
 		}
@@ -529,7 +529,7 @@ gor_vazumbrog_the_vaulthold = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 5000
 		}
 		province_modifiers = {
 			trade_value_modifier = 0.15
@@ -537,8 +537,8 @@ gor_vazumbrog_the_vaulthold = {
 		area_modifier = {		
 		}
 		country_modifiers = {
-			fire_damage = 0.04
-			shock_damage = 0.04
+			fire_damage = 0.075
+			shock_damage = 0.075
 			artificers_influence_modifier = 0.05
 			artificers_loyalty_modifier = 0.10
 		}
@@ -633,7 +633,7 @@ gor_ozumbrog_the_topaz_throne = {
 		area_modifier = {			
 		}
 		country_modifiers = {
-			manpower_in_culture_group_provinces = 0.04
+			manpower_in_culture_group_provinces = 0.1
 		}
 		on_upgraded = {
 		}
@@ -643,14 +643,14 @@ gor_ozumbrog_the_topaz_throne = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 2500
 		}
 		province_modifiers = {
 		}
 		area_modifier = {		
 		}
 		country_modifiers = {
-			manpower_in_culture_group_provinces = 0.08
+			manpower_in_culture_group_provinces = 0.15
 			ae_impact = -0.05
 		}
 		on_upgraded = {
@@ -668,7 +668,7 @@ gor_ozumbrog_the_topaz_throne = {
 		area_modifier = {		
 		}
 		country_modifiers = {
-			manpower_in_culture_group_provinces = 0.12
+			manpower_in_culture_group_provinces = 0.25
 			ae_impact = -0.1
 			national_focus_years = -5
 		}

--- a/common/great_projects/not_cannorian.txt
+++ b/common/great_projects/not_cannorian.txt
@@ -239,7 +239,7 @@ koroshesh_grain_port = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 6000
 		}
 		province_modifiers = {
 			province_trade_power_modifier = 0.33
@@ -335,7 +335,7 @@ zornartakel_naval_harbor = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 750
 		}
 		province_modifiers = {
 			local_sailors_modifier = 0.25
@@ -357,7 +357,7 @@ zornartakel_naval_harbor = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 2000
 		}
 		province_modifiers = {
 			local_sailors_modifier = 0.5
@@ -379,7 +379,7 @@ zornartakel_naval_harbor = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 4500
 		}
 		province_modifiers = {
 			local_sailors_modifier = 1
@@ -476,8 +476,10 @@ deshak_temple_of_the_elements = {
 		}
 		province_modifiers = {
 			local_tax_modifier = 0.1
+			local_development_cost = -0.025
 		}
 		area_modifier = {
+			local_tax_modifier = 0.1
 		}
 		country_modifiers = {
 			global_missionary_strength = 0.01
@@ -494,8 +496,10 @@ deshak_temple_of_the_elements = {
 		}
 		province_modifiers = {
 			local_tax_modifier = 0.15
+			local_development_cost = -0.05
 		}
 		area_modifier = {
+			local_tax_modifier = 0.1
 		}
 		country_modifiers = {
 			global_missionary_strength = 0.02
@@ -518,8 +522,10 @@ deshak_temple_of_the_elements = {
 		}
 		province_modifiers = {
 			local_tax_modifier = 0.25
+			local_development_cost = -0.075
 		}
 		area_modifier = {
+			local_tax_modifier = 0.1
 		}
 		country_modifiers = {
 			global_missionary_strength = 0.03
@@ -601,10 +607,10 @@ ekha_harbor = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 500
 		}
 		province_modifiers = {
-			local_sailors_modifier = 0.25
+			local_sailors_modifier = 0.5
 			ship_recruit_speed = -0.1
 		}
 		area_modifier = {
@@ -622,7 +628,7 @@ ekha_harbor = {
 			factor = 2500
 		}
 		province_modifiers = {
-			local_sailors_modifier = 0.5
+			local_sailors_modifier = 0.75
 			ship_recruit_speed = -0.2
 		}
 		area_modifier = {
@@ -823,7 +829,7 @@ dasmati_halls_of_reverence = {
 				tooltip = cannorian_monuments_can_use_tooltip_halls_of_reverence
 					OR = {
 						culture_group = bulwari
-				religion = old_bulwari_sun_cult
+						religion = old_bulwari_sun_cult
 					}
 			}
 			province_is_or_accepts_culture = yes
@@ -836,7 +842,7 @@ dasmati_halls_of_reverence = {
 				tooltip = cannorian_monuments_can_use_tooltip_halls_of_reverence
 					OR = {
 						culture_group = bulwari
-				religion = old_bulwari_sun_cult
+						religion = old_bulwari_sun_cult
 					}
 			}
 			province_is_or_accepts_culture = yes

--- a/common/great_projects/not_in_serpentspine.txt
+++ b/common/great_projects/not_in_serpentspine.txt
@@ -98,7 +98,7 @@ rubyhold_academy = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 2500
 		}
 		province_modifiers = {
 		}
@@ -221,7 +221,7 @@ ovdal_tungr_port_hold = {
 		area_modifier = {		
 		}
 		country_modifiers = {
-		navy_tradition_decay = -0.001
+		navy_tradition_decay = -0.005
 		}
 		on_upgraded = {
 		}
@@ -231,7 +231,7 @@ ovdal_tungr_port_hold = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 3000
 		}
 		province_modifiers = {
 		local_ship_repair = 0.25
@@ -242,7 +242,7 @@ ovdal_tungr_port_hold = {
 		}
 		country_modifiers = {
 		ship_durability = 0.025
-		navy_tradition_decay = -0.003
+		navy_tradition_decay = -0.0075
 		}
 		on_upgraded = {
 			owner = {
@@ -262,7 +262,7 @@ ovdal_tungr_port_hold = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 6000
 		}
 		province_modifiers = {
 		local_ship_repair = 0.5
@@ -273,7 +273,7 @@ ovdal_tungr_port_hold = {
 		}
 		country_modifiers = {
 		ship_durability = 0.05
-		navy_tradition_decay = -0.005
+		navy_tradition_decay = -0.01
 		flagship_durability = 0.5
 		}
 		on_upgraded = {
@@ -385,7 +385,7 @@ marrhold_gate_to_the_serpentspine = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 2500
 		}
 		province_modifiers = {
 			local_defensiveness = 0.25
@@ -698,7 +698,7 @@ silverforge_strongbellow_academy = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 4000
 		}
 		province_modifiers = {
 			local_defensiveness = 0.2
@@ -722,7 +722,7 @@ silverforge_strongbellow_academy = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 8000
 		}
 		province_modifiers = {
 			local_defensiveness = 0.33

--- a/common/great_projects/serpentsreach.txt
+++ b/common/great_projects/serpentsreach.txt
@@ -74,7 +74,7 @@ gor_burad_fireglass_forge = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 2500
 		}
 		province_modifiers = {
 			trade_goods_size = 1
@@ -96,7 +96,7 @@ gor_burad_fireglass_forge = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 8000
 		}
 		province_modifiers = {
 			trade_goods_size = 2
@@ -117,7 +117,7 @@ gor_burad_fireglass_forge = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 12000
 		}
 		province_modifiers = {
 			trade_goods_size = 3
@@ -481,7 +481,7 @@ arg_ordstun_great_clast_shafts = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 2250
 		}
 		province_modifiers = {
 			local_development_cost = -0.05
@@ -501,7 +501,7 @@ arg_ordstun_great_clast_shafts = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 4500
 		}
 		province_modifiers = {
 			local_development_cost = -0.1
@@ -521,7 +521,7 @@ arg_ordstun_great_clast_shafts = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 9000
 		}
 		province_modifiers = {
 			local_development_cost = -0.15
@@ -530,7 +530,7 @@ arg_ordstun_great_clast_shafts = {
 		area_modifier = {		
 		}
 		country_modifiers = {
-			development_cost = -0.1
+			development_cost = -0.075
 			production_efficiency = 0.1
 		}
 		on_upgraded = {
@@ -636,7 +636,7 @@ orlghelovar_great_waterfall = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 2500
 		}
 		province_modifiers = {
 			local_defensiveness = 0.2
@@ -656,7 +656,7 @@ orlghelovar_great_waterfall = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 8000
 		}
 		province_modifiers = {
 			local_defensiveness = 0.33
@@ -768,7 +768,7 @@ shaztundihr_marble_gate = {
 		area_modifier = {		
 		}
 		country_modifiers = {
-			fort_maintenance_modifier = -0.05
+			fort_maintenance_modifier = -0.15
 			prestige = 0.1
 		}
 		on_upgraded = {
@@ -779,7 +779,7 @@ shaztundihr_marble_gate = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 2500
 		}
 		province_modifiers = {
 			local_defensiveness = 0.2
@@ -788,7 +788,7 @@ shaztundihr_marble_gate = {
 		area_modifier = {			
 		}
 		country_modifiers = {
-			fort_maintenance_modifier = -0.1
+			fort_maintenance_modifier = -0.2
 			prestige = 0.25	
 		}
 		on_upgraded = {
@@ -799,7 +799,7 @@ shaztundihr_marble_gate = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 5000
 		}
 		province_modifiers = {
 			local_defensiveness = 0.33
@@ -808,7 +808,7 @@ shaztundihr_marble_gate = {
 		area_modifier = {		
 		}
 		country_modifiers = {
-			fort_maintenance_modifier = -0.15
+			fort_maintenance_modifier = -0.25
 			monthly_splendor = 1
 			prestige = 0.5
 		}

--- a/common/great_projects/south_castanor.txt
+++ b/common/great_projects/south_castanor.txt
@@ -116,7 +116,7 @@ marrhold_the_feather_academy = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 500
 		}
 		province_modifiers = {
 			local_institution_spread = 0.1
@@ -135,7 +135,7 @@ marrhold_the_feather_academy = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 3000
 		}
 		province_modifiers = {
 			local_institution_spread = 0.20
@@ -531,7 +531,7 @@ esthili_academy_of_magic = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 7500
 		}
 		province_modifiers = {
 			local_development_cost = -0.15

--- a/common/great_projects/the_borders.txt
+++ b/common/great_projects/the_borders.txt
@@ -80,7 +80,7 @@ sorncell_deepwater_harbor = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 2000
 		}
 		province_modifiers = {
 			local_development_cost = -0.05
@@ -101,7 +101,7 @@ sorncell_deepwater_harbor = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 4500
 		}
 		province_modifiers = {
 			local_development_cost = -0.1
@@ -124,7 +124,7 @@ sorncell_deepwater_harbor = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 9000
 		}
 		province_modifiers = {
 			local_development_cost = -0.15

--- a/common/great_projects/tree_of_stone.txt
+++ b/common/great_projects/tree_of_stone.txt
@@ -85,7 +85,8 @@ earthseed = {
 			trade_goods_size = 0.5
 			allowed_num_of_buildings = 1
 		}
-		area_modifier = {		
+		area_modifier = {
+			local_development_cost = -0.1
 		}
 		country_modifiers = {
 			global_missionary_strength = 0.005
@@ -113,7 +114,8 @@ earthseed = {
 			trade_goods_size = 1
 			allowed_num_of_buildings = 1
 		}
-		area_modifier = {		
+		area_modifier = {
+			local_development_cost = -0.15
 		}
 		country_modifiers = {
 			global_missionary_strength = 0.01
@@ -140,11 +142,12 @@ earthseed = {
 			factor = 5000
 		}
 		province_modifiers = {
-			local_development_cost = -0.6
+			local_development_cost = -0.5
 			trade_goods_size = 1.5
 			allowed_num_of_buildings = 2
 		}
-		area_modifier = {		
+		area_modifier = {
+			local_development_cost = -0.2
 		}
 		country_modifiers = {
 			global_missionary_strength = 0.015
@@ -522,7 +525,7 @@ ovdal_az_an_grand_lake_ballroom = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 1500
 		}
 		province_modifiers = {
 			local_unrest = -3
@@ -574,7 +577,7 @@ ovdal_az_an_grand_lake_ballroom = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 10000
 		}
 		province_modifiers = {
 			local_unrest = -10
@@ -723,7 +726,7 @@ hul_as_krakazol_breweries = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 9000
 		}
 		province_modifiers = {
 			local_defensiveness = 0.33

--- a/common/great_projects/west_castanor.txt
+++ b/common/great_projects/west_castanor.txt
@@ -124,7 +124,7 @@ ancardia_escanni_academy_of_war = {
 		area_modifier = {
 		}
 		country_modifiers = {
-			yearly_army_professionalism = 0.001
+			yearly_army_professionalism = 0.0033
 			drill_gain_modifier = 0.15
 		}
 		on_upgraded = {
@@ -143,7 +143,7 @@ ancardia_escanni_academy_of_war = {
 		area_modifier = {
 		}
 		country_modifiers = {
-			yearly_army_professionalism = 0.003
+			yearly_army_professionalism = 0.0066
 			drill_gain_modifier = 0.3
 		}
 		on_upgraded = {
@@ -162,7 +162,7 @@ ancardia_escanni_academy_of_war = {
 		area_modifier = {
 		}
 		country_modifiers = {
-			yearly_army_professionalism = 0.005
+			yearly_army_professionalism = 0.01
 			drill_gain_modifier = 0.5
 			free_leader_pool = 1
 		}
@@ -307,7 +307,7 @@ adenica_longlance_knights_academy = {
 		area_modifier = {
 		}
 		country_modifiers = {
-			army_tradition_decay = -0.001
+			army_tradition_decay = -0.0025
 			cavalry_shock = 0.05
 		}
 		on_upgraded = {
@@ -327,7 +327,7 @@ adenica_longlance_knights_academy = {
 		area_modifier = {
 		}
 		country_modifiers = {
-			army_tradition_decay = -0.003
+			army_tradition_decay = -0.005
 			cavalry_shock = 0.1
 		}
 		on_upgraded = {
@@ -356,7 +356,7 @@ adenica_longlance_knights_academy = {
 		area_modifier = {
 		}
 		country_modifiers = {
-			army_tradition_decay = -0.005
+			army_tradition_decay = -0.0075
 			cavalry_shock = 0.2
 			leader_land_shock = 1
 		}

--- a/common/great_projects/west_dameshead.txt
+++ b/common/great_projects/west_dameshead.txt
@@ -100,7 +100,7 @@ neckcliffe_the_imperial_dockyard = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 3500
 		}
 		province_modifiers = {
 			local_ship_repair = 0.25
@@ -133,7 +133,7 @@ neckcliffe_the_imperial_dockyard = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 7000
 		}
 		province_modifiers = {
 			local_ship_repair = 0.5

--- a/common/great_projects/western_dwarovar.txt
+++ b/common/great_projects/western_dwarovar.txt
@@ -218,7 +218,8 @@ amlharaz_assembly = {
 			local_production_efficiency = 0.05
 		}
 		country_modifiers = {
-			diplomatic_reputation = 0.25
+			diplomatic_reputation = 0.5
+			republican_tradition = 0.1
 		}
 		on_upgraded = {
 			add_base_production = 1
@@ -237,7 +238,8 @@ amlharaz_assembly = {
 			local_production_efficiency = 0.075
 		}
 		country_modifiers = {
-			diplomatic_reputation = 0.5
+			diplomatic_reputation = 1
+			republican_tradition = 0.2
 		}
 		on_upgraded = {
 			add_base_production = 2
@@ -266,8 +268,9 @@ amlharaz_assembly = {
 		}
 		country_modifiers = {
 			diplomats = 1
-			diplomatic_reputation = 1
+			diplomatic_reputation = 2
 			allow_client_states = yes
+			republican_tradition = 0.3
 		}
 		on_upgraded = {
 		add_base_production = 3
@@ -492,7 +495,7 @@ hall_of_the_ancestors = {
 			months = 120
 		}
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 2000
 		}
 		province_modifiers = {		
 		}
@@ -501,7 +504,7 @@ hall_of_the_ancestors = {
 		}
 		country_modifiers = {
 			manpower_in_true_faith_provinces = 0.05
-			tolerance_own = 0.5
+			global_missionary_strength = 0.01
 		}
 		on_upgraded = {
 		}
@@ -511,7 +514,7 @@ hall_of_the_ancestors = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 4000
 		}
 		province_modifiers = {		
 		}
@@ -520,7 +523,7 @@ hall_of_the_ancestors = {
 		}
 		country_modifiers = {
 			manpower_in_true_faith_provinces = 0.1
-			tolerance_own = 1
+			global_missionary_strength = 0.02
 			idea_cost = -0.025
 		}
 		on_upgraded = {
@@ -531,7 +534,7 @@ hall_of_the_ancestors = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 8000
 		}
 		province_modifiers = {			
 		}
@@ -540,7 +543,7 @@ hall_of_the_ancestors = {
 		}
 		country_modifiers = {
 			manpower_in_true_faith_provinces = 0.15
-			tolerance_own = 1.5
+			global_missionary_strength = 0.03
 			idea_cost = -0.05
 		}
 		on_upgraded = {
@@ -764,6 +767,7 @@ kozenad_brothel = {
 		}
 		province_modifiers = {
 			local_production_efficiency = 0.10
+			local_manpower_modifier = 0.1
 		}
 		area_modifier = {		
 		}
@@ -782,10 +786,11 @@ kozenad_brothel = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 2500
 		}
 		province_modifiers = {
 			local_production_efficiency = 0.15
+			local_manpower_modifier = 0.2
 		}
 		area_modifier = {			
 		}
@@ -804,10 +809,11 @@ kozenad_brothel = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 5000
 		}
 		province_modifiers = {
 			local_production_efficiency = 0.25
+			local_manpower_modifier = 0.3
 		}
 		area_modifier = {			
 		}
@@ -912,8 +918,8 @@ mithradhum_academy = {
 		area_modifier = {		
 		}
 		country_modifiers = {
-			army_tradition_decay = -0.001
-			yearly_army_professionalism = 0.001
+			army_tradition_decay = -0.002
+			yearly_army_professionalism = 0.0025
 		}
 		on_upgraded = {
 		}
@@ -932,8 +938,8 @@ mithradhum_academy = {
 		area_modifier = {		
 		}
 		country_modifiers = {
-			army_tradition_decay = -0.003
-			yearly_army_professionalism = 0.002
+			army_tradition_decay = -0.004
+			yearly_army_professionalism = 0.005
 		}
 		on_upgraded = {
 			owner = {
@@ -959,7 +965,7 @@ mithradhum_academy = {
 		}
 		country_modifiers = {
 			army_tradition_decay = -0.005
-			yearly_army_professionalism = 0.003
+			yearly_army_professionalism = 0.0075
 		}
 		on_upgraded = {
 			add_building = university
@@ -1804,7 +1810,7 @@ krakdhumvror_hold = {
 			months = 240
 		}
 		cost_to_upgrade = {
-			factor = 3500
+			factor = 2500
 		}
 		province_modifiers = {
 			trade_goods_size = 1
@@ -1833,7 +1839,7 @@ krakdhumvror_hold = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 5000
 		}
 		province_modifiers = {
 			trade_goods_size = 1.5


### PR DESCRIPTION
Mage Academy of Lorentainé - seems fine, maybe a lil strong
New Adea Naval School - made tier 1 a bit cheaper
Westport, Gateway to Aelantir - increased the settler growth modifier
Temple of Minara - increased improve relations modifier

The Hero's Gate - halved the inflation reduction modifier
Home of the Seg Band - moved 200 cost from tier 1 to tier 2
Hehodovar School of Architecture - looked fine
The Vaulthold - increased fire and shock damage modifiers and set the cost back to standard
The Topaz Throne (Gor Ozumbrog) - increased the manpower in culture group provinces (in part because the modifier is bugged making it a lot worse then it should be)

koroshesh grain port - made tier 3 slightly more expensive
Zornartakel Naval Harbor - made cheaper
Temple of the Elements (Deshak) - added a 10% area tax modifier and a small amount of province dev cost reduction
Ekha Harbor - made tier one really cheap as it is essentially useless, increased the provinces sailors modifier
Great Library of Aquatbar (Marblehead) - looked fine
Dasmati Halls of Reverence (Dasmatus) - looked fine

rubyhold - made tier 2 normal price again
Port-Hold of Ovdal Tungr - increased the naval tradition decay decrease, made a bit cheaper again
Marrhold, Gate to the Serpentspine - made tier 2 regular priced
Phokhao Citadel (Verkal Ozovar) - looked fine
Strongbellow Academy of Metallurgy - made slightly more expensive

Ghelebur Krakdhum (Gor Burad) - made a lot more expensive
The Warding Gate (Verkal Skomdihr) - looked fine
The Tunnel of Love (Ovdal Lodhum) - looked fine
Great Clast Shafts of Arg-Ôrdstun - reduced development cost reduction at tier 3, made more expensive
The Great Waterfall of Orlghelovar - moved 1k cost from tier 2 to tier 3
The Marble Gate (Shaztundihr) - increased the fort maintenance cost reduction, made normal priced

The Feather Academy (Marrhold) - moved half of the tier 1 price to tier 2
Bladeskeep - looked fine
Esthíli Academy of Magic - made tier 3 slightly more expensive

Deepwater Harbor of Sorncell (Celliande) - made it more expensive

earthseed - added an area dev cost reduction, slightly reduced tier 3 province dev cost reduction
The Kazandi Cannon Foundry - looked fine
The Green Gate (Grozumdhir) - looks weak but it has its niche
The Grand Lake Ballroom (Ovdal Az-An) - made tier 1 and 3 more expensive
The Hul-az-Krakazol Breweries - made tier 3 more expensive

Escanni Academy of War - increased the yearly army proffesionalism gain
Longlance Knights Academy (Adenica) - somewhat increased the yearly army tradition decay reduction modifier

The Imperial Dockyard (Neckcliffe) - made tier 2 and tier 3 more expensive

The Kronium Throne - looked fine
High Assembly of Amlharaz - doubled the diplo rep, gave 0.1-0.2-0.3 yearly republican tradition
Fortress of Verkal Vazkron - kinda weak but synergizes well with serpentspine being so defendable, so kept it as is
Hall of the Ancestors - slightly increased costs, replaced the tolerance of the true faith with missionary strength (1%-2%-3%)
Railyard of Er-Natvir - looked fine
Brothels of Verkal Kozenad - made cheaper, gave the province 10-20-30% manpower modifier
Goblinslayer Academy - increased the modifiers
Estates of Haraz Orldhûm (Haraz Orldhum) - looked fine
Asra Bank of Khugdihr - got the weird code, skipped
Food Silos of Orlazam - looks fine
Razstunad Mines - should be fine
Observatory of Dur-Vazhatun - looked fine
Frozen Hold of Krakdhumvror - made it cheaper
Aqueduct of Hul-Jorkad - looked fine
Sedadhûm Mining Settlement - should be fine cuz mithril


