### PR TITLE
Monument tweaks

### DIFF
--- a/common/great_projects/anb_monuments_aelantir.txt
+++ b/common/great_projects/anb_monuments_aelantir.txt
@@ -108,7 +108,7 @@ bone_citadel = {
 		}
 
 		country_modifiers = {
-			global_missionary_strength = 0.005
+			global_missionary_strength = 0.01
 			tolerance_own = 0.5
 			reduced_liberty_desire = 10
 		}
@@ -144,7 +144,7 @@ bone_citadel = {
 
 
 		country_modifiers = {
-			global_missionary_strength = 0.01
+			global_missionary_strength = 0.015
 			governing_capacity_modifier = 0.10
 			tolerance_own = 1
 			reduced_liberty_desire = 15
@@ -183,7 +183,7 @@ bone_citadel = {
 
 		
 		country_modifiers = {
-			global_missionary_strength = 0.02
+			global_missionary_strength = 0.025
 			governing_capacity_modifier = 0.25
 			tolerance_own = 1
 			reduced_liberty_desire = 15
@@ -572,7 +572,7 @@ ynnic_dam_mocbarja = {
 		}
 
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 4000
 		}
 
 		province_modifiers = {
@@ -1422,7 +1422,7 @@ ynnic_teal_keep = {
 		}
 
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 500
 		}
 
 		province_modifiers = {
@@ -1458,7 +1458,7 @@ ynnic_teal_keep = {
 		}
 
 		country_modifiers = {
-			reduced_liberty_desire = 10
+			reduced_liberty_desire = 15
 			advisor_pool = 1
 		}
 
@@ -1787,6 +1787,7 @@ ynnic_grand_temple_svemel = {
 
 		country_modifiers = {
 			tolerance_own = 1
+			global_missionary_strength = 0.01
 		}
 
 		on_upgraded = {
@@ -1813,6 +1814,7 @@ ynnic_grand_temple_svemel = {
 		country_modifiers = {
 			tolerance_own = 1.5
 			church_loyalty_modifier = 0.1
+			global_missionary_strength = 0.02
 		}
 
 		on_upgraded = {
@@ -1846,6 +1848,7 @@ ynnic_grand_temple_svemel = {
 			tolerance_own = 2
 			church_loyalty_modifier = 0.1
 			missionaries = 1
+			global_missionary_strength = 0.03
 		}
 
 		on_upgraded = {
@@ -1987,7 +1990,7 @@ ynnic_precursor_dome_stanyrhrada = {
 		}
 
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 500
 		}
 
 		province_modifiers = {

--- a/common/great_projects/anb_monuments_missions.txt
+++ b/common/great_projects/anb_monuments_missions.txt
@@ -66,7 +66,7 @@ the_south_citadel = {
 		}
 
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 500
 		}
 
 		province_modifiers = {
@@ -97,7 +97,7 @@ the_south_citadel = {
 		}
 
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 1000
 		}
 
 		province_modifiers = {
@@ -130,7 +130,7 @@ the_south_citadel = {
 		}
 
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 2500
 		}
 
 		province_modifiers = {
@@ -295,7 +295,7 @@ beikdugang_arsenal = {
 		}
 
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 10000
 		}
 
 		province_modifiers = {
@@ -991,7 +991,7 @@ elikhander_orbs = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 5000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -1021,7 +1021,7 @@ elikhander_orbs = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 10000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -1404,7 +1404,7 @@ eternal_pillar_1 = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2000
+			factor = 8000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -1601,7 +1601,7 @@ eternal_pillar_2 = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2000
+			factor = 8000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -1798,7 +1798,7 @@ eternal_pillar_3 = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2000
+			factor = 8000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -1995,7 +1995,7 @@ eternal_pillar_4 = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2000
+			factor = 8000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -2192,7 +2192,7 @@ eternal_pillar_5 = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2000
+			factor = 8000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -2389,7 +2389,7 @@ eternal_pillar_6 = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2000
+			factor = 8000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -2586,7 +2586,7 @@ eternal_pillar_7 = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2000
+			factor = 8000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -2783,7 +2783,7 @@ eternal_pillar_8 = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2000
+			factor =8000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -2980,7 +2980,7 @@ eternal_pillar_9 = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2000
+			factor = 8000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -3175,7 +3175,7 @@ well_of_majesty = {
 
 		#cost to upgrade to this level (0 for tier 0)
 		cost_to_upgrade = {
-			factor = 2000
+			factor = 8000
 		}
 
 		#what modifiers are added to the province when we have this project here on this tier
@@ -3690,7 +3690,7 @@ ravioli_bastion = {
 			months = 120
 		}
 		cost_to_upgrade = {#cost to upgrade to this level (0 for tier 0)
-			factor = 1000
+			factor = 5000
 		}
 		province_modifiers = {#what modifiers are added to the province when we have this project here on this tier
 			province_trade_power_value = 25 

--- a/common/great_projects/anb_monuments_rahen_haless.txt
+++ b/common/great_projects/anb_monuments_rahen_haless.txt
@@ -147,7 +147,7 @@ aksa_sanuyego = {
 
 		country_modifiers = {
 			global_ship_trade_power = 0.45
-			local_own_coast_naval_combat_bonus = 1
+			
 		}
 
 		on_upgraded = {
@@ -241,7 +241,7 @@ balkhangfa_palace = {
 		}
 
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 500
 		}
 
 		province_modifiers = {
@@ -313,7 +313,7 @@ balkhangfa_palace = {
 
 		
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 12000
 		}
 
 		
@@ -416,7 +416,7 @@ feiten_aerodrome = {
 		}
 		
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 2500
 		}
 		
 		province_modifiers = {
@@ -489,7 +489,7 @@ feiten_aerodrome = {
 		}
 		
 		cost_to_upgrade = {
-			factor = 10000
+			factor = 12000
 		}
 		
 		province_modifiers = {
@@ -609,7 +609,7 @@ hall_of_endless_debate = {
 		}
 
 		cost_to_upgrade = {
-			factor = 1000
+			factor = 500
 		}
 
 		province_modifiers = {
@@ -639,7 +639,7 @@ hall_of_endless_debate = {
 		}
 
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 3000
 		}
 
 		province_modifiers = {
@@ -672,7 +672,7 @@ hall_of_endless_debate = {
 		}
 
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 6000
 		}
 
 		province_modifiers = {
@@ -973,7 +973,7 @@ golden_palace = {
 		}
 
 		cost_to_upgrade = {
-			factor = 2500
+			factor = 3500
 		}
 
 		province_modifiers = {
@@ -1025,7 +1025,7 @@ golden_palace = {
 		}
 
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 6000
 		}
 
 		province_modifiers = {
@@ -1156,7 +1156,7 @@ godswall = {
 		}
 
 		country_modifiers = {
-			global_missionary_strength = 0.01
+			global_missionary_strength = 0.02
 		}
 
 		on_upgraded = {
@@ -1184,7 +1184,7 @@ godswall = {
 		}
 
 		country_modifiers = {
-			global_missionary_strength = 0.01
+			global_missionary_strength = 0.02
 			missionaries = 1
 			church_loyalty_modifier = 0.1
 		}

--- a/common/great_projects/anb_monuments_sarhal.txt
+++ b/common/great_projects/anb_monuments_sarhal.txt
@@ -52,7 +52,7 @@ elikhet_pyramid = {
 			local_autonomy = -0.05
 		}
 		country_modifiers = { 
-			imperial_mandate = 0.01 
+			imperial_mandate = 0.025
 		}
 		on_upgraded = {}
 	}
@@ -67,7 +67,7 @@ elikhet_pyramid = {
 			local_autonomy = -0.1
 		}
 		country_modifiers = { 
-			imperial_mandate = 0.03
+			imperial_mandate = 0.05
 			global_missionary_strength = 0.01
 		}
 		on_upgraded = {}
@@ -83,7 +83,7 @@ elikhet_pyramid = {
 			local_autonomy = -0.15
 		}
 		country_modifiers = { 
-			imperial_mandate = 0.05
+			imperial_mandate = 0.075
 			global_missionary_strength = 0.02
 		}
 		on_upgraded = {
@@ -224,7 +224,7 @@ decadence_statues = {
 
 	tier_1 = {
 		upgrade_time = { months = 120 }
-		cost_to_upgrade = { factor = 1000 }
+		cost_to_upgrade = { factor = 500 }
 		province_modifiers = {
 			trade_value_modifier = 0.15
 		}
@@ -238,7 +238,7 @@ decadence_statues = {
 
 	tier_2 = {
 		upgrade_time = { months = 240 }
-		cost_to_upgrade = { factor = 2500 }
+		cost_to_upgrade = { factor = 3500 }
 		province_modifiers = {
 			trade_value_modifier = 0.3
 		}
@@ -253,7 +253,7 @@ decadence_statues = {
 
 	tier_3 = {
 		upgrade_time = { months = 480 }
-		cost_to_upgrade = { factor = 5000 }
+		cost_to_upgrade = { factor = 7000 }
 		province_modifiers = {
 			trade_value_modifier = 0.5
 		}
@@ -588,7 +588,7 @@ shadowroot_matriarch_purified = {
 		}
 
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 7500
 		}
 
 		province_modifiers = {
@@ -737,6 +737,7 @@ lizzardfolk_port = {
 		}
 		
 		country_modifiers = {
+			trade_efficiency = 0.025
 		}
 
 		on_upgraded = {
@@ -789,7 +790,7 @@ lizzardfolk_port = {
 		}
 
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 10000
 		}
 
 		province_modifiers = {
@@ -1009,7 +1010,7 @@ first_mihipha_college = {
 		}
 		country_modifiers = {
 			mages_loyalty_modifier = 0.10
-			all_power_cost = -0.01
+			all_power_cost = -0.025
 		}
 
 		on_upgraded = {

--- a/common/great_projects/bomdan.txt
+++ b/common/great_projects/bomdan.txt
@@ -61,7 +61,7 @@ prukakhin_bazaar_of_blood_and_ivory = {
 		}
 		province_modifiers = {
 			local_development_cost = -0.05
-			province_trade_power_modifier = 0.1
+			province_trade_power_modifier = 0.25
 			local_sailors_modifier = 0.25
 		}
 		area_modifier = {
@@ -86,7 +86,7 @@ prukakhin_bazaar_of_blood_and_ivory = {
 		}
 		province_modifiers = {
 			local_development_cost = -0.1
-			province_trade_power_modifier = 0.2
+			province_trade_power_modifier = 0.5
 			local_sailors_modifier = 0.5
 		}
 		area_modifier = {
@@ -121,7 +121,7 @@ prukakhin_bazaar_of_blood_and_ivory = {
 		}
 		province_modifiers = {
 			local_development_cost = -0.15
-			province_trade_power_modifier = 0.33
+			province_trade_power_modifier = 0.75
 			local_sailors_modifier = 1
 		}
 		area_modifier = {
@@ -243,7 +243,7 @@ phaethmen_di_phaemruk_shipyard_district = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 5000
+			factor = 7000
 		}
 		province_modifiers = {
 			local_development_cost = -0.15
@@ -341,7 +341,7 @@ phaethmen_di_the_saccharine_garden = {
 		area_modifier = {
 		}
 		country_modifiers = {
-			prestige_decay = -0.001
+			prestige_decay = -0.0025
 			recover_army_morale_speed = 0.05
 		}
 		on_upgraded = {
@@ -363,7 +363,7 @@ phaethmen_di_the_saccharine_garden = {
 		area_modifier = {
 		}
 		country_modifiers = {
-			prestige_decay = -0.003
+			prestige_decay = -0.005
 			recover_army_morale_speed = 0.1
 		}
 		on_upgraded = {
@@ -386,7 +386,7 @@ phaethmen_di_the_saccharine_garden = {
 		area_modifier = {
 		}
 		country_modifiers = {
-			prestige_decay = -0.005
+			prestige_decay = -0.0075
 			recover_army_morale_speed = 0.15
 			monthly_splendor = 1
 		}

--- a/common/great_projects/jade_mines.txt
+++ b/common/great_projects/jade_mines.txt
@@ -454,7 +454,7 @@ verkal_dromak_mage_academy = {
 			months = 480
 		}
 		cost_to_upgrade = {
-			factor = 7000
+			factor = 10000
 		}
 		province_modifiers = {
 			local_defensiveness = 0.33
@@ -610,7 +610,7 @@ vurdriz_andriz_bastion = {
 		country_modifiers = {
 			defensiveness = 0.1
 			global_garrison_growth = 0.33
-			rival_border_fort_maintenance = -0.9
+			rival_border_fort_maintenance = -0.75
 		}
 		on_upgraded = {
 			add_base_manpower = 3


### PR DESCRIPTION
bone_citadel - boosted missionary strength 
dobondotimveb - wasn't sure how strong their church bonni are so left it as is
ynnic dams - didn't touch
ynnic_teal_keep - halved tier 1 price, gave tier 2 5%  extra liberty desire reduction
ynnic_tranvit_hippodrome - looked fine
ynnic_grand_temple_svemel - added 1%-2%-3% missionary strength
ynnic_precursor_dome_stanyrhrada - made tier 1 half the price
deathsand_lab - looked fine
city_that_never_sleeps - looked fine
heart_of_the_effelai - I  would have to dig to far in code to see how good this actually is

elikhet_pyramid - gave more mandate growth
bronze_dragon_academy - looked fine
decadence_statues - made tier 1 half priced, made tier 2 and tier 3 more expensive
shadowroot_matriarch - looked fine
shadowroot_matriarch_purified - made tier 3 50% more expensive
lizzardfolk_port - gave tier 1 2.5% trade effiency made tier 3 double the price
first_mihipha_college - gave tier 3 more power cost reduction (2.5% total)
esuvrem - should be fine
tower of muhaqaar - looks good
kuiika gamyi - looked fine
koroshesh library - looks fine
great_merfolk_canal - is a canal

the_south_citadel - made it a lot cheaper
beikdugang_arsenal - doubled tier 3 cost, might want to tweak further
beikdugang_lights - kinda weak, but mt monument
anzarzax_palace -  MT
elikhander_pyramid - MT
elikhander_orbs - made tier 2 and 3 double as expensive
elikhander_sphinx - MT
all 9 eternal pillars - quadripled the cost for tier 3
well_of_majesty - quadripled the cost for tier 3
scp_bureau_hq - looked fine
icgm - looked fine
ravioli_bastion - tier 2 now 5x as expensive

Aksa Sanuyego - removed a bugged modifier (local modifier in country scope)
balkhangfa_palace - made tier 1 half price, made tier 3 way more expensive
feiten_aerodrome - made more expensive
hall_of_endless_debate - moved 500 cost from tier 1 to 2, made tier 3 1k more expensive
oracle_mountain - maybe a little weak, but eh
golden_palace - more expensive now too
godswall - increased the missionary strength at tier 1 and 2
sarisung_city - looked fine
palace_of_divine_call - looked fine
budanphre_canal - canal

Bazaar of Blood and Ivory (Prukakhin) - increased the province's trade power modifier by a lot
Phaemruk Shipyard District (Phaethmen Di) - tier 3 more expensive
The Saccharine Garden (Phaethmen Di) - increased the prestige decay reduction modifier
Weapon Market of Lapnam Amrik (Lapnam Amrik) - looked fine
Teplinbasiet Arena (Lapnam Amrik) - looked fine
Necropolis of Bim Lau - looked fine

Gardens of Tuwad-Dhûmakon - looked fine
Trade Halls of Gronstunad - looked fine, maybe a little strong
Mage Academy of Verkal Dromak - made tier 3 more expensive
Bastion of Vûrdriz-Ândriz - lowered the rival fort maintenance reduction to 75%
The Emerald Spire - looked fine

